### PR TITLE
Replace all sha1 checksums with sha256

### DIFF
--- a/derby.rb
+++ b/derby.rb
@@ -3,7 +3,7 @@ require "formula"
 class Derby < Formula
   homepage "http://db.apache.org/derby/"
   url "http://mirror.serversupportforum.de/apache/db/derby/db-derby-10.11.1.1/db-derby-10.11.1.1-bin.tar.gz"
-  sha1 "aa198b8795bb8a70fb7597a22d4331ade463b34c"
+  sha256 "68e06b5e859282b6bd7cfc1a801d1bf855a589515e14b5f3e8ea732d76c3fd34"
 
   option "with-examples", "Install examples"
   option "with-docs", "Install documentation"

--- a/hsqldb.rb
+++ b/hsqldb.rb
@@ -3,7 +3,7 @@ require "formula"
 class Hsqldb < Formula
   homepage "http://hsqldb.org/"
   url "https://downloads.sourceforge.net/project/hsqldb/hsqldb/hsqldb_2_3/hsqldb-2.3.2.zip"
-  sha1 "be0062a00d1b2835491e593aca764298c6ddde0b"
+  sha256 "573082ab3f1c8f02c1f496b9aae15b74f1b5aedf3812ef300e90ead3047e5fb0"
 
   option "with-docs", "Install documentation"
 

--- a/sqlite-jdbc.rb
+++ b/sqlite-jdbc.rb
@@ -3,7 +3,7 @@ require 'formula'
 class SqliteJdbc < Formula
   homepage "https://bitbucket.org/xerial/sqlite-jdbc/"
   url "https://bitbucket.org/xerial/sqlite-jdbc/downloads/sqlite-jdbc-3.7.2.jar"
-  sha1 "cea9f7f8e6bcb580d953a8651fb8391640de0f85"
+  sha256 "266a3e21ca1d021aeb3ae8bf23ac8f1a03ffe86000ae7ae8f245c193c24a0fa0"
 
   def install
     libexec.install Dir["*.jar"]


### PR DESCRIPTION
sha1 checksums is now deprecated and homebrew shows warning like this:

Warning: Calling Formula.sha1 is deprecated!
Use Formula.sha256 instead.
/usr/local/Library/Taps/gbeine/homebrew-java/derby.rb:6:in `<class:Derby>'
Please report this to the gbeine/java tap! 