### PR TITLE
Fixed the formula styling based on command: brew style --fix *.rb

### DIFF
--- a/derby.rb
+++ b/derby.rb
@@ -10,12 +10,12 @@ class Derby < Formula
 
   def install
     # Remove Windows scripts
-    rm_rf Dir['bin/*.bat']
+    rm_rf Dir["bin/*.bat"]
 
     prefix.install_metafiles
-    libexec.install Dir['bin', 'lib']
-    (libexec/'examples').install Dir['demo/*'] if build.with? 'examples'
-    doc.install Dir['docs/*', 'javadoc'] if build.with? 'docs'
+    libexec.install Dir["bin", "lib"]
+    (libexec/"examples").install Dir["demo/*"] if build.with? "examples"
+    doc.install Dir["docs/*", "javadoc"] if build.with? "docs"
 
     bin.install_symlink "#{libexec}/bin/NetworkServerControl" => "NetworkServerControl"
     bin.install_symlink "#{libexec}/bin/dblook" => "dblook"
@@ -27,5 +27,4 @@ class Derby < Formula
     bin.install_symlink "#{libexec}/bin/stopNetworkServer" => "stopNetworkServer"
     bin.install_symlink "#{libexec}/bin/sysinfo" => "sysinfo"
   end
-
 end

--- a/hsqldb.rb
+++ b/hsqldb.rb
@@ -12,5 +12,4 @@ class Hsqldb < Formula
     libexec.install Dir["hsqldb/lib/*.jar"]
     doc.install Dir["hsqldb/doc/*"] if build.with? "docs"
   end
-
 end

--- a/mysql-connector-java.rb
+++ b/mysql-connector-java.rb
@@ -1,4 +1,4 @@
-require 'formula'
+require "formula"
 
 class MysqlConnectorJava < Formula
   homepage "http://dev.mysql.com/downloads/connector/j/"
@@ -11,5 +11,4 @@ class MysqlConnectorJava < Formula
     libexec.install Dir["*.jar"]
     doc.install Dir["docs/*"]
   end
-
 end

--- a/postgresql-jdbc.rb
+++ b/postgresql-jdbc.rb
@@ -1,4 +1,4 @@
-require 'formula'
+require "formula"
 
 class PostgresqlJdbc < Formula
   homepage "http://jdbc.postgresql.org/about/about.html"

--- a/redshift-jdbc.rb
+++ b/redshift-jdbc.rb
@@ -1,4 +1,4 @@
-require 'formula'
+require "formula"
 
 class RedshiftJdbc < Formula
   homepage "https://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html"

--- a/sqlite-jdbc.rb
+++ b/sqlite-jdbc.rb
@@ -1,4 +1,4 @@
-require 'formula'
+require "formula"
 
 class SqliteJdbc < Formula
   homepage "https://bitbucket.org/xerial/sqlite-jdbc/"
@@ -8,5 +8,4 @@ class SqliteJdbc < Formula
   def install
     libexec.install Dir["*.jar"]
   end
-
 end


### PR DESCRIPTION
Some small changes.

```
== derby.rb ==
C: 13: 15: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 16: 25: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 16: 32: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 17: 14: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 17: 38: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 17: 63: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 18: 21: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 18: 31: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 18: 57: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 30:  1: [Corrected] Extra empty line detected at class body end.
== hsqldb.rb ==
C: 15:  1: [Corrected] Extra empty line detected at class body end.
== mysql-connector-java.rb ==
C:  1:  9: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 14:  1: [Corrected] Extra empty line detected at class body end.
== postgresql-jdbc.rb ==
C:  1:  9: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
== redshift-jdbc.rb ==
C:  1:  9: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
== sqlite-jdbc.rb ==
C:  1:  9: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
C: 11:  1: [Corrected] Extra empty line detected at class body end.
```